### PR TITLE
Fix: allowed using <a> to navigate out to absolute URLs and fixed routing to allow navigating to any page in the app as the first load

### DIFF
--- a/public/src/_routing/render.js
+++ b/public/src/_routing/render.js
@@ -1,9 +1,0 @@
-import { routes } from "../routes.js";
-export function render(route) {
-    if (routes[route]) {
-        const app = document.getElementById('app');
-        app.innerHTML = `<${routes[route].identifier}></${routes[route].identifier}>`;
-    } else {
-        throw new Error(`Page ${route} not found.`);
-    }
-}

--- a/public/src/_routing/start.js
+++ b/public/src/_routing/start.js
@@ -1,14 +1,28 @@
-import { render } from "./render.js";
+import { routes } from "../routes.js";
 const BaseURL = window.location.href;
-export function start() {
-    const currentURL = window.location.href;
-    if(currentURL == BaseURL) {
-        render('');
-        return;
+const parts = BaseURL.split('/');
+const firstRoute=parts[3] ?? '' ;
+const domain = `${parts[0]}//${parts[2]}/`;
+/**
+ * 
+ * @param {*} route either a route defined in the route.js, or a link starting with http for redirect.
+ */
+export function navigate(route) {
+    if (routes[route]) {
+        const app = document.getElementById('app');
+        app.innerHTML = `<${routes[route].identifier}></${routes[route].identifier}>`;
+    } else if (route.includes('http')){
+        window.location.href = route;
+    } 
+    else {
+        console.error(`Page ${route} not found.`);
+        if (route == ''){
+            throw new Error(`UNRECOVERABLE ROUTING STATE: The site is failing to route to the ('') homepage. This should only happen if the '' route is not in the routes lookup in /routes.js `)
+        }else{
+            navigate(''); 
+        }
     }
-    const parts = currentURL.split('/');
-    const route = parts[parts.length - 1];
-    render(route);
+    history.pushState(null, null, `${domain}${route}`);
 }
 
-render('');
+navigate(firstRoute);

--- a/public/src/_wrappers/WebComponent.js
+++ b/public/src/_wrappers/WebComponent.js
@@ -1,4 +1,4 @@
-import { start } from "../_routing/start.js";
+import { navigate } from "../_routing/start.js";
 const BaseURL = window.location.href;
 /**
  * This is a wrapper for creating web components
@@ -53,8 +53,7 @@ export class WebComponent extends HTMLElement{
             anchor.addEventListener('click', function(event) {
                 event.preventDefault();
                 const href = anchor.getAttribute('href');
-                history.pushState(null, null, `${BaseURL}${href}`);
-                start();
+                navigate(href);
             });
         });
     }


### PR DESCRIPTION
We will need to put validation on pages to make sure the user is logged in before rendering a page. An idea for that is to just default render the login page on hard navigation to any other page.